### PR TITLE
Migrate to LapackE from CLapack

### DIFF
--- a/lsLibla.cpp
+++ b/lsLibla.cpp
@@ -52,12 +52,12 @@ namespace ls {
 
         if (numRows == 0) return oResult;
 
-        lapack_complex_double *A = new lapack_complex_double[numRows * numRows];
-        memset(A, 0, sizeof(lapack_complex_double) * numRows * numRows);
-        lapack_complex_double *eigVals = new lapack_complex_double[numRows];
-        memset(eigVals, 0, sizeof(lapack_complex_double) * numRows);
-        lapack_complex_double *work = new lapack_complex_double[lwork];
-        memset(work, 0, sizeof(lapack_complex_double) * lwork);
+        std::complex<double> *A = new std::complex<double>[numRows * numRows];
+        memset(A, 0, sizeof(std::complex<double>) * numRows * numRows);
+        std::complex<double> *eigVals = new std::complex<double>[numRows];
+        memset(eigVals, 0, sizeof(std::complex<double>) * numRows);
+        std::complex<double> *work = new std::complex<double>[lwork];
+        memset(work, 0, sizeof(std::complex<double>) * lwork);
         double *rwork = new double[lwork];
         memset(rwork, 0, sizeof(double) * lwork);
 
@@ -65,7 +65,7 @@ namespace ls {
         for (int i = 0; i < numRows; i++) {
             for (int j = 0; j < numCols; j++) {
                 index = (j + numRows * i);
-                A[index].r = oMatrix(i, j);
+                A[index].real(oMatrix(i, j));
             }
         }
 
@@ -74,8 +74,8 @@ namespace ls {
 
 
         for (int i = 0; i < numRows; i++) {
-            Complex complex(ls::RoundToTolerance(eigVals[i].r, gLapackTolerance),
-                            ls::RoundToTolerance(eigVals[i].i, gLapackTolerance));
+            Complex complex(ls::RoundToTolerance(eigVals[i].real(), gLapackTolerance),
+                            ls::RoundToTolerance(eigVals[i].imag(), gLapackTolerance));
             oResult.push_back(complex);
         }
 
@@ -102,12 +102,12 @@ namespace ls {
         if (numRows != numCols)
             throw ApplicationException("Input Matrix must be square", "Expecting a Square Matrix");
 
-        lapack_complex_double *A = new lapack_complex_double[numRows * numRows];
-        memset(A, 0, sizeof(lapack_complex_double) * numRows * numRows);
-        lapack_complex_double *eigVals = new lapack_complex_double[numRows];
-        memset(eigVals, 0, sizeof(lapack_complex_double) * numRows);
-        lapack_complex_double *work = new lapack_complex_double[lwork];
-        memset(work, 0, sizeof(lapack_complex_double) * lwork);
+        std::complex<double> *A = new std::complex<double>[numRows * numRows];
+        memset(A, 0, sizeof(std::complex<double>) * numRows * numRows);
+        std::complex<double> *eigVals = new std::complex<double>[numRows];
+        memset(eigVals, 0, sizeof(std::complex<double>) * numRows);
+        std::complex<double> *work = new std::complex<double>[lwork];
+        memset(work, 0, sizeof(std::complex<double>) * lwork);
         double *rwork = new double[lwork];
         memset(rwork, 0, sizeof(double) * lwork);
 
@@ -116,8 +116,8 @@ namespace ls {
             for (int j = 0; j < numCols; j++) {
                 index = (j + numRows * i);
 
-                A[index].r = real(oMatrix(j, i));
-                A[index].i = imag(oMatrix(j, i));
+                A[index].real(real(oMatrix(j, i)));
+                A[index].imag(imag(oMatrix(j, i)));
 
             }
         }
@@ -127,8 +127,8 @@ namespace ls {
 
 
         for (int i = 0; i < numRows; i++) {
-            Complex complex(ls::RoundToTolerance(eigVals[i].r, gLapackTolerance),
-                            ls::RoundToTolerance(eigVals[i].i, gLapackTolerance));
+            Complex complex(ls::RoundToTolerance(eigVals[i].real(), gLapackTolerance),
+                            ls::RoundToTolerance(eigVals[i].imag(), gLapackTolerance));
             oResult.push_back(complex);
         }
 
@@ -556,14 +556,14 @@ namespace ls {
 
         if (numRows == 0) return new ComplexMatrix();
 
-        lapack_complex_double *A = new lapack_complex_double[numRows * numRows];
-        memset(A, 0, sizeof(lapack_complex_double) * numRows * numRows);
-        lapack_complex_double *eigVals = new lapack_complex_double[numRows];
-        memset(eigVals, 0, sizeof(lapack_complex_double) * numRows);
-        lapack_complex_double *vr = new lapack_complex_double[numRows * numRows];
-        memset(vr, 0, sizeof(lapack_complex_double) * numRows * numRows);
-        lapack_complex_double *work = new lapack_complex_double[lwork];
-        memset(work, 0, sizeof(lapack_complex_double) * lwork);
+        std::complex<double> *A = new std::complex<double>[numRows * numRows];
+        memset(A, 0, sizeof(std::complex<double>) * numRows * numRows);
+        std::complex<double> *eigVals = new std::complex<double>[numRows];
+        memset(eigVals, 0, sizeof(std::complex<double>) * numRows);
+        std::complex<double> *vr = new std::complex<double>[numRows * numRows];
+        memset(vr, 0, sizeof(std::complex<double>) * numRows * numRows);
+        std::complex<double> *work = new std::complex<double>[lwork];
+        memset(work, 0, sizeof(std::complex<double>) * lwork);
         double *rwork = new double[lwork];
         memset(rwork, 0, sizeof(double) * lwork);
 
@@ -571,7 +571,7 @@ namespace ls {
         for (int i = 0; i < numRows; i++) {
             for (int j = 0; j < numCols; j++) {
                 index = (j + numRows * i);
-                A[index].r = oMatrix(j, i);
+                A[index].real(oMatrix(j, i));
             }
         }
 
@@ -584,8 +584,8 @@ namespace ls {
             for (int j = 0; j < numRows; j++) {
                 index = (j + numRows * i);
                 Complex complexNr(
-                        ls::RoundToTolerance(vr[index].r, gLapackTolerance),
-                        ls::RoundToTolerance(vr[index].i, gLapackTolerance));
+                    ls::RoundToTolerance(vr[index].real(), gLapackTolerance),
+                    ls::RoundToTolerance(vr[index].imag(), gLapackTolerance));
 
                 (*oResult)(i, j) = complexNr;//(.set(complex.Real, complex.Imag);
             }
@@ -615,14 +615,14 @@ namespace ls {
 
         if (numRows == 0) return new ComplexMatrix();
 
-        lapack_complex_double *A = new lapack_complex_double[numRows * numRows];
-        memset(A, 0, sizeof(lapack_complex_double) * numRows * numRows);
-        lapack_complex_double *eigVals = new lapack_complex_double[numRows];
-        memset(eigVals, 0, sizeof(lapack_complex_double) * numRows);
-        lapack_complex_double *vr = new lapack_complex_double[numRows * numRows];
-        memset(vr, 0, sizeof(lapack_complex_double) * numRows * numRows);
-        lapack_complex_double *work = new lapack_complex_double[lwork];
-        memset(work, 0, sizeof(lapack_complex_double) * lwork);
+        std::complex<double> *A = new std::complex<double>[numRows * numRows];
+        memset(A, 0, sizeof(std::complex<double>) * numRows * numRows);
+        std::complex<double> *eigVals = new std::complex<double>[numRows];
+        memset(eigVals, 0, sizeof(std::complex<double>) * numRows);
+        std::complex<double> *vr = new std::complex<double>[numRows * numRows];
+        memset(vr, 0, sizeof(std::complex<double>) * numRows * numRows);
+        std::complex<double> *work = new std::complex<double>[lwork];
+        memset(work, 0, sizeof(std::complex<double>) * lwork);
         double *rwork = new double[lwork];
         memset(rwork, 0, sizeof(double) * lwork);
 
@@ -630,8 +630,8 @@ namespace ls {
         for (int i = 0; i < numRows; i++) {
             for (int j = 0; j < numCols; j++) {
                 index = (j + numRows * i);
-                A[index].r = real(oMatrix(j, i));
-                A[index].i = imag(oMatrix(j, i));
+                A[index].real(real(oMatrix(j, i)));
+                A[index].imag(imag(oMatrix(j, i)));
             }
         }
 
@@ -644,8 +644,8 @@ namespace ls {
             for (int j = 0; j < numRows; j++) {
                 index = (j + numRows * i);
                 Complex complexNr(
-                        ls::RoundToTolerance(vr[index].r, gLapackTolerance),
-                        ls::RoundToTolerance(vr[index].i, gLapackTolerance));
+                    ls::RoundToTolerance(vr[index].real(), gLapackTolerance),
+                    ls::RoundToTolerance(vr[index].imag(), gLapackTolerance));
 
                 (*oResult)(i, j) = complexNr;//.set(complex.Real, complex.Imag);
             }
@@ -745,16 +745,16 @@ namespace ls {
 
         lapack_int lwork = min_MN * min_MN + 2 * min_MN + max_MN; // specified in dgesdd description for job 'A'
         lapack_int lrwork = 5 * min_MN * min_MN + 7 * min_MN;
-        lapack_complex_double *A = new lapack_complex_double[numRows * numCols];
-        memset(A, 0, sizeof(lapack_complex_double) * numRows * numCols);
-        lapack_complex_double *U = new lapack_complex_double[numRows * numRows];
-        memset(U, 0, sizeof(lapack_complex_double) * numRows * numRows);
-        lapack_complex_double *VT = new lapack_complex_double[numCols * numCols];
-        memset(VT, 0, sizeof(lapack_complex_double) * numCols * numCols);
+        std::complex<double> *A = new std::complex<double>[numRows * numCols];
+        memset(A, 0, sizeof(std::complex<double>) * numRows * numCols);
+        std::complex<double> *U = new std::complex<double>[numRows * numRows];
+        memset(U, 0, sizeof(std::complex<double>) * numRows * numRows);
+        std::complex<double> *VT = new std::complex<double>[numCols * numCols];
+        memset(VT, 0, sizeof(std::complex<double>) * numCols * numCols);
         double *S = new double[min_MN];
         memset(S, 0, sizeof(double) * min_MN);
-        lapack_complex_double *work = new lapack_complex_double[lwork];
-        memset(work, 0, sizeof(lapack_complex_double) * lwork);
+        std::complex<double> *work = new std::complex<double>[lwork];
+        memset(work, 0, sizeof(std::complex<double>) * lwork);
         double *rwork = new double[lrwork];
         memset(rwork, 0, sizeof(double) * lrwork);
         lapack_int *iwork = new lapack_int[8 * min_MN];
@@ -763,8 +763,8 @@ namespace ls {
         for (int i = 0; i < numRows; i++) {
             for (int j = 0; j < numCols; j++) {
                 index = (j + numRows * i);
-                A[index].r = real(inputMatrix(j, i));
-                A[index].i = imag(inputMatrix(j, i));
+                A[index].real(real(inputMatrix(j, i)));
+                A[index].imag(imag(inputMatrix(j, i)));
             }
         }
 
@@ -777,8 +777,8 @@ namespace ls {
         for (int i = 0; i < numRows; i++) {
             for (int j = 0; j < numRows; j++) {
                 index = (j + numRows * i);
-                (*outU)(j, i) = Complex((ls::RoundToTolerance(U[index].r, gLapackTolerance),
-                        ls::RoundToTolerance(U[index].i, gLapackTolerance)));
+                (*outU)(j, i) = Complex((ls::RoundToTolerance(U[index].real(), gLapackTolerance),
+                                         ls::RoundToTolerance(U[index].imag(), gLapackTolerance)));
             }
         }
 
@@ -786,8 +786,8 @@ namespace ls {
         for (int i = 0; i < numCols; i++) {
             for (int j = 0; j < numCols; j++) {
                 index = (j + numCols * i);
-                (*outV)(i, j) = Complex(ls::RoundToTolerance(VT[index].r, gLapackTolerance),
-                                        ls::RoundToTolerance(-VT[index].i, gLapackTolerance));
+                (*outV)(i, j) = Complex(ls::RoundToTolerance(VT[index].real(), gLapackTolerance),
+                                        ls::RoundToTolerance(-VT[index].imag(), gLapackTolerance));
             }
         }
 
@@ -1080,11 +1080,11 @@ namespace ls {
             throw ApplicationException("Input Matrix must be square", "Expecting a Square Matrix");
         }
 
-        lapack_complex_double *A = new lapack_complex_double[numRows * numRows];
+        std::complex<double> *A = new std::complex<double>[numRows * numRows];
         for (int i = 0; i < numRows; i++) {
             for (int j = 0; j < numRows; j++) {
-                A[i + numRows * j].r = real(oMatrix(i, j));
-                A[i + numRows * j].i = imag(oMatrix(i, j));
+                A[i + numRows * j].real(real(oMatrix(i, j)));
+                A[i + numRows * j].imag(imag(oMatrix(i, j)));
             }
         }
 
@@ -1093,8 +1093,8 @@ namespace ls {
 
         lapack_int *ipvt = new lapack_int[numRows];
         memset(ipvt, 0, sizeof(lapack_int) * numRows);
-        lapack_complex_double *work = new lapack_complex_double[numRows];
-        memset(work, 0, sizeof(lapack_complex_double) * numRows);
+        std::complex<double> *work = new std::complex<double>[numRows];
+        memset(work, 0, sizeof(std::complex<double>) * numRows);
 
         // Carry out LU Factorization
         lapack_int info;
@@ -1119,8 +1119,8 @@ namespace ls {
         oResultMatrix = new ComplexMatrix(numRows, numRows);
         for (int i = 0; i < numRows; i++) {
             for (int j = 0; j < numRows; j++) {
-                Complex tols(ls::RoundToTolerance(A[(i + numRows * j)].r, gLapackTolerance),
-                             ls::RoundToTolerance(A[(i + numRows * j)].i, gLapackTolerance));
+                Complex tols(ls::RoundToTolerance(A[(i + numRows * j)].real(), gLapackTolerance),
+                             ls::RoundToTolerance(A[(i + numRows * j)].imag(), gLapackTolerance));
                 (*oResultMatrix)(i, j) = tols;
 
             }
@@ -1147,11 +1147,11 @@ namespace ls {
             throw ApplicationException("Input Matrix must be square", "Expecting a Square Matrix");
         }
 
-        lapack_complex_double *A = new lapack_complex_double[numRows * numRows];
+        std::complex<double> *A = new std::complex<double>[numRows * numRows];
         for (int i = 0; i < numRows; i++) {
             for (int j = 0; j < numRows; j++) {
-                A[i + numRows * j].r = real(oMatrix(i, j));
-                A[i + numRows * j].i = imag(oMatrix(i, j));
+                A[i + numRows * j].real(real(oMatrix(i, j)));
+                A[i + numRows * j].imag(imag(oMatrix(i, j)));
             }
         }
 
@@ -1160,8 +1160,8 @@ namespace ls {
 
         lapack_int *ipvt = new lapack_int[numRows];
         memset(ipvt, 0, sizeof(lapack_int) * numRows);
-        lapack_complex_double *work = new lapack_complex_double[numRows];
-        memset(work, 0, sizeof(lapack_complex_double) * numRows);
+        std::complex<double> *work = new std::complex<double>[numRows];
+        memset(work, 0, sizeof(std::complex<double>) * numRows);
 
         // Carry out LU Factorization
         lapack_int info;
@@ -1186,8 +1186,8 @@ namespace ls {
         oResultMatrix = new ComplexMatrix(numRows, numRows);
         for (int i = 0; i < numRows; i++) {
             for (int j = 0; j < numRows; j++) {
-                Complex tols(ls::RoundToTolerance(A[(i + numRows * j)].r, gLapackTolerance),
-                             ls::RoundToTolerance(A[(i + numRows * j)].i, gLapackTolerance));
+                Complex tols(ls::RoundToTolerance(A[(i + numRows * j)].real(), gLapackTolerance),
+                             ls::RoundToTolerance(A[(i + numRows * j)].imag(), gLapackTolerance));
                 (*oResultMatrix)(i, j) = tols;
             }
         }

--- a/lsLibla.cpp
+++ b/lsLibla.cpp
@@ -12,16 +12,11 @@
 #include <cmath>
 #include <sstream>
 #include <string.h>
+#include <lapacke.h>
 #include "lsLibla.h"
 #include "lsMatrix.h"
 #include "lsUtils.h"
 
-extern "C"
-{
-#include "f2c.h"
-#include "clapack.h"
-
-}
 //---------------------------------------------------------------------------
 
 namespace ls {

--- a/lsLibla.cpp
+++ b/lsLibla.cpp
@@ -52,12 +52,12 @@ namespace ls {
 
         if (numRows == 0) return oResult;
 
-        doublecomplex *A = new doublecomplex[numRows * numRows];
-        memset(A, 0, sizeof(doublecomplex) * numRows * numRows);
-        doublecomplex *eigVals = new doublecomplex[numRows];
-        memset(eigVals, 0, sizeof(doublecomplex) * numRows);
-        doublecomplex *work = new doublecomplex[lwork];
-        memset(work, 0, sizeof(doublecomplex) * lwork);
+        lapack_complex_double *A = new lapack_complex_double[numRows * numRows];
+        memset(A, 0, sizeof(lapack_complex_double) * numRows * numRows);
+        lapack_complex_double *eigVals = new lapack_complex_double[numRows];
+        memset(eigVals, 0, sizeof(lapack_complex_double) * numRows);
+        lapack_complex_double *work = new lapack_complex_double[lwork];
+        memset(work, 0, sizeof(lapack_complex_double) * lwork);
         doublereal *rwork = new doublereal[lwork];
         memset(rwork, 0, sizeof(doublereal) * lwork);
 
@@ -102,12 +102,12 @@ namespace ls {
         if (numRows != numCols)
             throw ApplicationException("Input Matrix must be square", "Expecting a Square Matrix");
 
-        doublecomplex *A = new doublecomplex[numRows * numRows];
-        memset(A, 0, sizeof(doublecomplex) * numRows * numRows);
-        doublecomplex *eigVals = new doublecomplex[numRows];
-        memset(eigVals, 0, sizeof(doublecomplex) * numRows);
-        doublecomplex *work = new doublecomplex[lwork];
-        memset(work, 0, sizeof(doublecomplex) * lwork);
+        lapack_complex_double *A = new lapack_complex_double[numRows * numRows];
+        memset(A, 0, sizeof(lapack_complex_double) * numRows * numRows);
+        lapack_complex_double *eigVals = new lapack_complex_double[numRows];
+        memset(eigVals, 0, sizeof(lapack_complex_double) * numRows);
+        lapack_complex_double *work = new lapack_complex_double[lwork];
+        memset(work, 0, sizeof(lapack_complex_double) * lwork);
         doublereal *rwork = new doublereal[lwork];
         memset(rwork, 0, sizeof(doublereal) * lwork);
 
@@ -556,14 +556,14 @@ namespace ls {
 
         if (numRows == 0) return new ComplexMatrix();
 
-        doublecomplex *A = new doublecomplex[numRows * numRows];
-        memset(A, 0, sizeof(doublecomplex) * numRows * numRows);
-        doublecomplex *eigVals = new doublecomplex[numRows];
-        memset(eigVals, 0, sizeof(doublecomplex) * numRows);
-        doublecomplex *vr = new doublecomplex[numRows * numRows];
-        memset(vr, 0, sizeof(doublecomplex) * numRows * numRows);
-        doublecomplex *work = new doublecomplex[lwork];
-        memset(work, 0, sizeof(doublecomplex) * lwork);
+        lapack_complex_double *A = new lapack_complex_double[numRows * numRows];
+        memset(A, 0, sizeof(lapack_complex_double) * numRows * numRows);
+        lapack_complex_double *eigVals = new lapack_complex_double[numRows];
+        memset(eigVals, 0, sizeof(lapack_complex_double) * numRows);
+        lapack_complex_double *vr = new lapack_complex_double[numRows * numRows];
+        memset(vr, 0, sizeof(lapack_complex_double) * numRows * numRows);
+        lapack_complex_double *work = new lapack_complex_double[lwork];
+        memset(work, 0, sizeof(lapack_complex_double) * lwork);
         doublereal *rwork = new doublereal[lwork];
         memset(rwork, 0, sizeof(doublereal) * lwork);
 
@@ -615,14 +615,14 @@ namespace ls {
 
         if (numRows == 0) return new ComplexMatrix();
 
-        doublecomplex *A = new doublecomplex[numRows * numRows];
-        memset(A, 0, sizeof(doublecomplex) * numRows * numRows);
-        doublecomplex *eigVals = new doublecomplex[numRows];
-        memset(eigVals, 0, sizeof(doublecomplex) * numRows);
-        doublecomplex *vr = new doublecomplex[numRows * numRows];
-        memset(vr, 0, sizeof(doublecomplex) * numRows * numRows);
-        doublecomplex *work = new doublecomplex[lwork];
-        memset(work, 0, sizeof(doublecomplex) * lwork);
+        lapack_complex_double *A = new lapack_complex_double[numRows * numRows];
+        memset(A, 0, sizeof(lapack_complex_double) * numRows * numRows);
+        lapack_complex_double *eigVals = new lapack_complex_double[numRows];
+        memset(eigVals, 0, sizeof(lapack_complex_double) * numRows);
+        lapack_complex_double *vr = new lapack_complex_double[numRows * numRows];
+        memset(vr, 0, sizeof(lapack_complex_double) * numRows * numRows);
+        lapack_complex_double *work = new lapack_complex_double[lwork];
+        memset(work, 0, sizeof(lapack_complex_double) * lwork);
         doublereal *rwork = new doublereal[lwork];
         memset(rwork, 0, sizeof(doublereal) * lwork);
 
@@ -745,16 +745,16 @@ namespace ls {
 
         lapack_int lwork = min_MN * min_MN + 2 * min_MN + max_MN; // specified in dgesdd description for job 'A'
         lapack_int lrwork = 5 * min_MN * min_MN + 7 * min_MN;
-        doublecomplex *A = new doublecomplex[numRows * numCols];
-        memset(A, 0, sizeof(doublecomplex) * numRows * numCols);
-        doublecomplex *U = new doublecomplex[numRows * numRows];
-        memset(U, 0, sizeof(doublecomplex) * numRows * numRows);
-        doublecomplex *VT = new doublecomplex[numCols * numCols];
-        memset(VT, 0, sizeof(doublecomplex) * numCols * numCols);
+        lapack_complex_double *A = new lapack_complex_double[numRows * numCols];
+        memset(A, 0, sizeof(lapack_complex_double) * numRows * numCols);
+        lapack_complex_double *U = new lapack_complex_double[numRows * numRows];
+        memset(U, 0, sizeof(lapack_complex_double) * numRows * numRows);
+        lapack_complex_double *VT = new lapack_complex_double[numCols * numCols];
+        memset(VT, 0, sizeof(lapack_complex_double) * numCols * numCols);
         doublereal *S = new doublereal[min_MN];
         memset(S, 0, sizeof(doublereal) * min_MN);
-        doublecomplex *work = new doublecomplex[lwork];
-        memset(work, 0, sizeof(doublecomplex) * lwork);
+        lapack_complex_double *work = new lapack_complex_double[lwork];
+        memset(work, 0, sizeof(lapack_complex_double) * lwork);
         doublereal *rwork = new doublereal[lrwork];
         memset(rwork, 0, sizeof(doublereal) * lrwork);
         lapack_int *iwork = new lapack_int[8 * min_MN];
@@ -1080,7 +1080,7 @@ namespace ls {
             throw ApplicationException("Input Matrix must be square", "Expecting a Square Matrix");
         }
 
-        doublecomplex *A = new doublecomplex[numRows * numRows];
+        lapack_complex_double *A = new lapack_complex_double[numRows * numRows];
         for (int i = 0; i < numRows; i++) {
             for (int j = 0; j < numRows; j++) {
                 A[i + numRows * j].r = real(oMatrix(i, j));
@@ -1093,8 +1093,8 @@ namespace ls {
 
         lapack_int *ipvt = new lapack_int[numRows];
         memset(ipvt, 0, sizeof(lapack_int) * numRows);
-        doublecomplex *work = new doublecomplex[numRows];
-        memset(work, 0, sizeof(doublecomplex) * numRows);
+        lapack_complex_double *work = new lapack_complex_double[numRows];
+        memset(work, 0, sizeof(lapack_complex_double) * numRows);
 
         // Carry out LU Factorization
         lapack_int info;
@@ -1147,7 +1147,7 @@ namespace ls {
             throw ApplicationException("Input Matrix must be square", "Expecting a Square Matrix");
         }
 
-        doublecomplex *A = new doublecomplex[numRows * numRows];
+        lapack_complex_double *A = new lapack_complex_double[numRows * numRows];
         for (int i = 0; i < numRows; i++) {
             for (int j = 0; j < numRows; j++) {
                 A[i + numRows * j].r = real(oMatrix(i, j));
@@ -1160,8 +1160,8 @@ namespace ls {
 
         lapack_int *ipvt = new lapack_int[numRows];
         memset(ipvt, 0, sizeof(lapack_int) * numRows);
-        doublecomplex *work = new doublecomplex[numRows];
-        memset(work, 0, sizeof(doublecomplex) * numRows);
+        lapack_complex_double *work = new lapack_complex_double[numRows];
+        memset(work, 0, sizeof(lapack_complex_double) * numRows);
 
         // Carry out LU Factorization
         lapack_int info;

--- a/lsLibla.cpp
+++ b/lsLibla.cpp
@@ -41,10 +41,10 @@ namespace ls {
 
         vector<Complex> oResult;
 
-        integer numRows = oMatrix.numRows();
-        integer numCols = oMatrix.numCols();
-        integer lwork = 2 * numRows;
-        integer info;
+        lapack_int numRows = oMatrix.numRows();
+        lapack_int numCols = oMatrix.numCols();
+        lapack_int lwork = 2 * numRows;
+        lapack_int info;
 
         if (numRows != numCols) {
             throw ApplicationException("Input Matrix must be square", "Expecting a Square Matrix");
@@ -94,10 +94,10 @@ namespace ls {
 
         vector<Complex> oResult;
 
-        integer numRows = oMatrix.numRows();
-        integer numCols = oMatrix.numCols();
-        integer lwork = 2 * numRows;
-        integer info;
+        lapack_int numRows = oMatrix.numRows();
+        lapack_int numCols = oMatrix.numCols();
+        lapack_int lwork = 2 * numRows;
+        lapack_int info;
 
         if (numRows != numCols)
             throw ApplicationException("Input Matrix must be square", "Expecting a Square Matrix");
@@ -148,8 +148,8 @@ namespace ls {
 
         vector<DoubleMatrix *> oResult;
 
-        integer row = oMatrix.numRows();
-        integer col = oMatrix.numCols();
+        lapack_int row = oMatrix.numRows();
+        lapack_int col = oMatrix.numCols();
 
         if (row * col == 0) {
             DoubleMatrix *oMatrixQ = new DoubleMatrix(row, row);
@@ -161,8 +161,8 @@ namespace ls {
             return oResult;
         }
 
-        integer minRowCol = min(row, col);
-        integer lwork = 16 * col;
+        lapack_int minRowCol = min(row, col);
+        lapack_int lwork = 16 * col;
 
         doublereal *A = oMatrix.getCopy(true);
 
@@ -193,10 +193,10 @@ namespace ls {
             tau = new doublereal[minRowCol];
             memset(tau, 0, sizeof(doublereal) * minRowCol);
         }
-        integer *jpvt = NULL;
+        lapack_int *jpvt = NULL;
         if (col) {
-            jpvt = new integer[col];
-            memset(jpvt, 0, sizeof(integer) * col);
+            jpvt = new lapack_int[col];
+            memset(jpvt, 0, sizeof(lapack_int) * col);
         }
         doublereal *work = NULL;
         if (lwork) {
@@ -204,7 +204,7 @@ namespace ls {
             memset(work, 0, lwork);
         }
 
-        integer info;
+        lapack_int info;
         int out;
 
         //Log(lDebug5) << "Input:\n"<<ls::print(row, col, A);
@@ -306,8 +306,8 @@ namespace ls {
         //Log(lDebug5) << "=== getQR " << endl;
         //Log(lDebug5) << "======================================================" << endl << endl;
 
-        integer row = oMatrix.numRows();
-        integer col = oMatrix.numCols();
+        lapack_int row = oMatrix.numRows();
+        lapack_int col = oMatrix.numCols();
         if (row * col == 0) {
             vector<DoubleMatrix *> oResult;
             DoubleMatrix *oMatrixQ = new DoubleMatrix(row, row);
@@ -317,8 +317,8 @@ namespace ls {
             return oResult;
         }
 
-        integer lwork = 16 * col;
-        integer minRowCol = min(row, col);
+        lapack_int lwork = 16 * col;
+        lapack_int minRowCol = min(row, col);
 
         doublereal *Q = new doublereal[row * row];
         doublereal *R = new doublereal[row * col];
@@ -330,7 +330,7 @@ namespace ls {
 
         //Log(lDebug5) << "Input:\n"<<ls::print(row, col, A);
 
-        integer info;
+        lapack_int info;
         dgeqrf_(&row, &col, A, &row, tau, work, &lwork, &info);
 
         //Log(lDebug5) << "A: after dgeqrt)\n"<<ls::print(row, col, A);
@@ -426,13 +426,13 @@ namespace ls {
         //Log(lDebug5) << "======================================================" << endl << endl;
         DoubleMatrix *oTranspose = oMatrix.getTranspose();
 
-        integer numRows = oTranspose->numRows();
-        integer numCols = oTranspose->numCols();
+        lapack_int numRows = oTranspose->numRows();
+        lapack_int numCols = oTranspose->numCols();
 
         // determine sizes
-        integer min_MN = min(numRows, numCols);
-        integer max_MN = max(numRows, numCols);
-        integer lwork = 3 * min_MN * min_MN + max(max_MN, 4 * min_MN * min_MN + 4 * min_MN); // 'A'
+        lapack_int min_MN = min(numRows, numCols);
+        lapack_int max_MN = max(numRows, numCols);
+        lapack_int lwork = 3 * min_MN * min_MN + max(max_MN, 4 * min_MN * min_MN + 4 * min_MN); // 'A'
 
         // allocate arrays for lapack
         doublereal *A = oTranspose->getCopy(true);
@@ -444,9 +444,9 @@ namespace ls {
         memset(U, 0, sizeof(doublereal) * numRows * numRows);
         doublereal *VT = new doublereal[numCols * numCols];
         memset(VT, 0, sizeof(doublereal) * numCols * numCols);
-        integer *iwork = new integer[8 * min_MN];
+        lapack_int *iwork = new lapack_int[8 * min_MN];
 
-        integer info;
+        lapack_int info;
         char jobz = 'A';
         dgesdd_(&jobz, &numRows, &numCols, A, &numRows, S, U, &numRows, VT, &numCols, work, &lwork, iwork, &info);
 
@@ -507,24 +507,24 @@ namespace ls {
 
         vector<double> oResult;
 
-        integer numRows = oMatrix.numRows();
-        integer numCols = oMatrix.numCols();
+        lapack_int numRows = oMatrix.numRows();
+        lapack_int numCols = oMatrix.numCols();
 
-        integer min_MN = min(numRows, numCols);
-        integer max_MN = max(numRows, numCols);
+        lapack_int min_MN = min(numRows, numCols);
+        lapack_int max_MN = max(numRows, numCols);
 
         if (min_MN == 0) return oResult;
 
-        integer lwork = 3 * min_MN + max(max_MN, 7 * min_MN);    // specified in dgesdd description
+        lapack_int lwork = 3 * min_MN + max(max_MN, 7 * min_MN);    // specified in dgesdd description
 
         doublereal *A = oMatrix.getCopy(true);
         doublereal *S = new doublereal[min_MN];
         memset(S, 0, sizeof(doublereal) * min_MN);
         doublereal *work = new doublereal[lwork];
         memset(work, 0, sizeof(doublereal) * lwork);
-        integer *iwork = new integer[8 * min_MN];
+        lapack_int *iwork = new lapack_int[8 * min_MN];
 
-        integer info;
+        lapack_int info;
         char jobz = 'N';
         dgesdd_(&jobz, &numRows, &numCols, A, &numRows, S, NULL, &numRows, NULL, &numCols, work, &lwork, iwork, &info);
 
@@ -546,10 +546,10 @@ namespace ls {
         //Log(lDebug5) << "=== getEigenVectors " << endl;
         //Log(lDebug5) << "======================================================" << endl << endl;
 
-        integer numRows = oMatrix.numRows();
-        integer numCols = oMatrix.numCols();
-        integer lwork = 2 * numRows;
-        integer info;
+        lapack_int numRows = oMatrix.numRows();
+        lapack_int numCols = oMatrix.numCols();
+        lapack_int lwork = 2 * numRows;
+        lapack_int info;
 
         if (numRows != numCols)
             throw ApplicationException("Input Matrix must be square", "Expecting a Square Matrix");
@@ -605,10 +605,10 @@ namespace ls {
         //Log(lDebug5) << "=== getEigenVectors " << endl;
         //Log(lDebug5) << "======================================================" << endl << endl;
 
-        integer numRows = oMatrix.numRows();
-        integer numCols = oMatrix.numCols();
-        integer lwork = 2 * numRows;
-        integer info;
+        lapack_int numRows = oMatrix.numRows();
+        lapack_int numCols = oMatrix.numCols();
+        lapack_int lwork = 2 * numRows;
+        lapack_int info;
 
         if (numRows != numCols)
             throw ApplicationException("Input Matrix must be square", "Expecting a Square Matrix");
@@ -666,16 +666,16 @@ namespace ls {
         //Log(lDebug5) << "=== getSingularValsBySVD " << endl;
         //Log(lDebug5) << "======================================================" << endl << endl;
 
-        integer numRows = inputMatrix.numRows();
-        integer numCols = inputMatrix.numCols();
+        lapack_int numRows = inputMatrix.numRows();
+        lapack_int numCols = inputMatrix.numCols();
 
-        integer min_MN = min(numRows, numCols);
-        integer max_MN = max(numRows, numCols);
+        lapack_int min_MN = min(numRows, numCols);
+        lapack_int max_MN = max(numRows, numCols);
 
         if (min_MN == 0) return;
 
-        //integer lwork    = 3*min_MN + max(max_MN, 7*min_MN);    // specified in dgesdd description
-        integer lwork = 3 * min_MN * min_MN +
+        //lapack_int lwork    = 3*min_MN + max(max_MN, 7*min_MN);    // specified in dgesdd description
+        lapack_int lwork = 3 * min_MN * min_MN +
                         max(max_MN, 4 * min_MN * min_MN + 4 * min_MN); // specified in dgesdd description for job 'A'
 
         doublereal *A = inputMatrix.getCopy(true);
@@ -687,10 +687,10 @@ namespace ls {
         memset(S, 0, sizeof(doublereal) * min_MN);
         doublereal *work = new doublereal[lwork];
         memset(work, 0, sizeof(doublereal) * lwork);
-        integer *iwork = new integer[8 * min_MN];
+        lapack_int *iwork = new lapack_int[8 * min_MN];
 
 
-        integer info;
+        lapack_int info;
         char jobz = 'A';
         dgesdd_(&jobz, &numRows, &numCols, A, &numRows, S, U, &numRows, VT, &numCols, work, &lwork, iwork, &info);
 
@@ -735,16 +735,16 @@ namespace ls {
         //Log(lDebug5) << "=== getSingularValsBySVD " << endl;
         //Log(lDebug5) << "======================================================" << endl << endl;
 
-        integer numRows = inputMatrix.numRows();
-        integer numCols = inputMatrix.numCols();
+        lapack_int numRows = inputMatrix.numRows();
+        lapack_int numCols = inputMatrix.numCols();
 
-        integer min_MN = min(numRows, numCols);
-        integer max_MN = max(numRows, numCols);
+        lapack_int min_MN = min(numRows, numCols);
+        lapack_int max_MN = max(numRows, numCols);
 
         if (min_MN == 0) return;
 
-        integer lwork = min_MN * min_MN + 2 * min_MN + max_MN; // specified in dgesdd description for job 'A'
-        integer lrwork = 5 * min_MN * min_MN + 7 * min_MN;
+        lapack_int lwork = min_MN * min_MN + 2 * min_MN + max_MN; // specified in dgesdd description for job 'A'
+        lapack_int lrwork = 5 * min_MN * min_MN + 7 * min_MN;
         doublecomplex *A = new doublecomplex[numRows * numCols];
         memset(A, 0, sizeof(doublecomplex) * numRows * numCols);
         doublecomplex *U = new doublecomplex[numRows * numRows];
@@ -757,7 +757,7 @@ namespace ls {
         memset(work, 0, sizeof(doublecomplex) * lwork);
         doublereal *rwork = new doublereal[lrwork];
         memset(rwork, 0, sizeof(doublereal) * lrwork);
-        integer *iwork = new integer[8 * min_MN];
+        lapack_int *iwork = new lapack_int[8 * min_MN];
 
         int index;
         for (int i = 0; i < numRows; i++) {
@@ -768,7 +768,7 @@ namespace ls {
             }
         }
 
-        integer info;
+        lapack_int info;
         char jobz = 'A';
         zgesdd_(&jobz, &numRows, &numCols, A, &numRows, S, U, &numRows, VT, &numCols, work, &lwork, rwork, iwork,
                 &info);
@@ -808,23 +808,23 @@ namespace ls {
     }
 
     double getRCond(DoubleMatrix &oMatrix) {
-        integer numRows = oMatrix.numRows();
-        integer numCols = oMatrix.numCols();
+        lapack_int numRows = oMatrix.numRows();
+        lapack_int numCols = oMatrix.numCols();
 
-        integer minRC = min(numRows, numCols);
+        lapack_int minRC = min(numRows, numCols);
 
         if (minRC == 0) {
             return 0.0;
         }
 
         doublereal *A = (doublereal *) oMatrix.getCopy(true);
-        integer *vecP = new integer[minRC];
-        memset(vecP, 0, (sizeof(integer) * minRC));
+        lapack_int *vecP = new lapack_int[minRC];
+        memset(vecP, 0, (sizeof(lapack_int) * minRC));
 
-        integer info;
+        lapack_int info;
 
         char norm = '1';
-        integer order = numRows * numCols;
+        lapack_int order = numRows * numCols;
 
         double *work = new doublereal[4 * order];
         memset(work, 0, sizeof(double) * 4 * order);
@@ -833,8 +833,8 @@ namespace ls {
         dgetrf_(&numRows, &numCols, A, &numRows, vecP, &info);
         ls::checkTolerance(numRows * numCols, A, gLapackTolerance);
 
-        integer *iwork = new integer[numRows];
-        memset(iwork, 0, sizeof(integer) * numRows);
+        lapack_int *iwork = new lapack_int[numRows];
+        memset(iwork, 0, sizeof(lapack_int) * numRows);
 
         memset(work, 0, sizeof(double) * 4 * order);
 
@@ -853,8 +853,8 @@ namespace ls {
         //Log(lDebug5) << "=== getLU " << endl;
         //Log(lDebug5) << "======================================================" << endl << endl;
 
-        integer numRows = oMatrix.numRows();
-        integer numCols = oMatrix.numCols();
+        lapack_int numRows = oMatrix.numRows();
+        lapack_int numCols = oMatrix.numCols();
 
         int minRC = min(numRows, numCols);
 
@@ -872,10 +872,10 @@ namespace ls {
         }
 
         doublereal *A = (doublereal *) oMatrix.getCopy(true);
-        integer *vecP = new integer[minRC];
-        memset(vecP, 0, (sizeof(integer) * minRC));
+        lapack_int *vecP = new lapack_int[minRC];
+        memset(vecP, 0, (sizeof(lapack_int) * minRC));
 
-        integer info;
+        lapack_int info;
         dgetrf_(&numRows, &numCols, A, &numRows, vecP, &info);
 
         ls::print(numRows, numCols, A);
@@ -939,20 +939,20 @@ namespace ls {
         //Log(lDebug5) << "=== getLUwithFullPivoting " << endl;
         //Log(lDebug5) << "======================================================" << endl << endl;
 
-        integer numRows = oMatrix.numRows();
-        integer numCols = oMatrix.numCols();
+        lapack_int numRows = oMatrix.numRows();
+        lapack_int numCols = oMatrix.numCols();
 
         if (numRows != numCols)
             throw ApplicationException("Input Matrix must be square", "Expecting a Square Matrix");
 
 
         doublereal *A = (doublereal *) oMatrix.getCopy(true);
-        integer *vecP = new integer[numRows];
-        memset(vecP, 0, (sizeof(integer) * numRows));
-        integer *vecQ = new integer[numRows];
-        memset(vecQ, 0, (sizeof(integer) * numRows));
+        lapack_int *vecP = new lapack_int[numRows];
+        memset(vecP, 0, (sizeof(lapack_int) * numRows));
+        lapack_int *vecQ = new lapack_int[numRows];
+        memset(vecQ, 0, (sizeof(lapack_int) * numRows));
 
-        integer info;
+        lapack_int info;
         dgetc2_(&numRows, A, &numRows, vecP, vecQ, &info);
 
         DoubleMatrix *L = new DoubleMatrix(numRows, numRows);
@@ -1025,8 +1025,8 @@ namespace ls {
         //Log(lDebug5) << "======================================================" << endl << endl;
         DoubleMatrix *oResultMatrix = NULL;
 
-        integer numRows = oMatrix.numRows();
-        integer numCols = oMatrix.numCols();
+        lapack_int numRows = oMatrix.numRows();
+        lapack_int numCols = oMatrix.numCols();
 
 
         if (numRows != numCols)
@@ -1034,8 +1034,8 @@ namespace ls {
 
 
         doublereal *A = oMatrix.getCopy(true);
-        integer *ipvt = new integer[numRows];
-        memset(ipvt, 0, sizeof(integer) * numRows);
+        lapack_int *ipvt = new lapack_int[numRows];
+        memset(ipvt, 0, sizeof(lapack_int) * numRows);
         doublereal *work = new doublereal[numRows];
         memset(work, 0, sizeof(doublereal) * numRows);
 
@@ -1043,7 +1043,7 @@ namespace ls {
 
 
         // Carry out LU Factorization
-        integer info;
+        lapack_int info;
         dgetrf_(&numRows, &numRows, A, &numRows, ipvt, &info);
         if (info < 0)
             throw ApplicationException("Error in dgetrf : LU Factorization", "Illegal Value");
@@ -1073,8 +1073,8 @@ namespace ls {
         //Log(lDebug5) << "======================================================" << endl;
 
         ComplexMatrix *oResultMatrix = NULL;
-        integer numRows = oMatrix.numRows();
-        integer numCols = oMatrix.numCols();
+        lapack_int numRows = oMatrix.numRows();
+        lapack_int numCols = oMatrix.numCols();
 
         if (numRows != numCols) {
             throw ApplicationException("Input Matrix must be square", "Expecting a Square Matrix");
@@ -1091,13 +1091,13 @@ namespace ls {
         ////Log(lDebug5) << "Input Matrix 1D: \n";
         //ls::print(numRows, numRows, A);
 
-        integer *ipvt = new integer[numRows];
-        memset(ipvt, 0, sizeof(integer) * numRows);
+        lapack_int *ipvt = new lapack_int[numRows];
+        memset(ipvt, 0, sizeof(lapack_int) * numRows);
         doublecomplex *work = new doublecomplex[numRows];
         memset(work, 0, sizeof(doublecomplex) * numRows);
 
         // Carry out LU Factorization
-        integer info;
+        lapack_int info;
         zgetrf_(&numRows, &numRows, A, &numRows, ipvt, &info);
 
         if (info < 0) {
@@ -1140,8 +1140,8 @@ namespace ls {
         //Log(lDebug5) << "======================================================" << endl;
 
         ComplexMatrix *oResultMatrix = NULL;
-        integer numRows = oMatrix.numRows();
-        integer numCols = oMatrix.numCols();
+        lapack_int numRows = oMatrix.numRows();
+        lapack_int numCols = oMatrix.numCols();
 
         if (numRows != numCols) {
             throw ApplicationException("Input Matrix must be square", "Expecting a Square Matrix");
@@ -1158,13 +1158,13 @@ namespace ls {
         ////Log(lDebug5) << "Input Matrix 1D: \n";
         //ls::print(numRows, numRows, A);
 
-        integer *ipvt = new integer[numRows];
-        memset(ipvt, 0, sizeof(integer) * numRows);
+        lapack_int *ipvt = new lapack_int[numRows];
+        memset(ipvt, 0, sizeof(lapack_int) * numRows);
         doublecomplex *work = new doublecomplex[numRows];
         memset(work, 0, sizeof(doublecomplex) * numRows);
 
         // Carry out LU Factorization
-        integer info;
+        lapack_int info;
         zgetrf_(&numRows, &numRows, A, &numRows, ipvt, &info);
 
         if (info < 0) {

--- a/lsLibla.cpp
+++ b/lsLibla.cpp
@@ -58,8 +58,8 @@ namespace ls {
         memset(eigVals, 0, sizeof(lapack_complex_double) * numRows);
         lapack_complex_double *work = new lapack_complex_double[lwork];
         memset(work, 0, sizeof(lapack_complex_double) * lwork);
-        doublereal *rwork = new doublereal[lwork];
-        memset(rwork, 0, sizeof(doublereal) * lwork);
+        double *rwork = new double[lwork];
+        memset(rwork, 0, sizeof(double) * lwork);
 
         int index;
         for (int i = 0; i < numRows; i++) {
@@ -108,8 +108,8 @@ namespace ls {
         memset(eigVals, 0, sizeof(lapack_complex_double) * numRows);
         lapack_complex_double *work = new lapack_complex_double[lwork];
         memset(work, 0, sizeof(lapack_complex_double) * lwork);
-        doublereal *rwork = new doublereal[lwork];
-        memset(rwork, 0, sizeof(doublereal) * lwork);
+        double *rwork = new double[lwork];
+        memset(rwork, 0, sizeof(double) * lwork);
 
         int index;
         for (int i = 0; i < numRows; i++) {
@@ -164,23 +164,23 @@ namespace ls {
         lapack_int minRowCol = min(row, col);
         lapack_int lwork = 16 * col;
 
-        doublereal *A = oMatrix.getCopy(true);
+        double *A = oMatrix.getCopy(true);
 
 
-        doublereal *Q = NULL;
+        double *Q = NULL;
         if (row * row) {
-            Q = new doublereal[row * row];
-            memset(Q, 0, sizeof(doublereal) * row * row);
+            Q = new double[row * row];
+            memset(Q, 0, sizeof(double) * row * row);
         }
-        doublereal *R = NULL;
+        double *R = NULL;
         if (row * col) {
-            R = new doublereal[row * col];
-            memset(R, 0, sizeof(doublereal) * row * col);
+            R = new double[row * col];
+            memset(R, 0, sizeof(double) * row * col);
         }
-        doublereal *P = NULL;
+        double *P = NULL;
         if (col * col) {
-            P = new doublereal[col * col];
-            memset(P, 0, sizeof(doublereal) * col * col);
+            P = new double[col * col];
+            memset(P, 0, sizeof(double) * col * col);
         }
 
         //Log(lDebug5) << "before dorgqr A:\n"    << ls::print(row, col, A);
@@ -188,19 +188,19 @@ namespace ls {
         //Log(lDebug5) << endl << endl << "R: \n"    << ls::print(row, col, R);
         //Log(lDebug5) << endl << endl << "P: \n"    << ls::print(col, col, P);
 
-        doublereal *tau = NULL;
+        double *tau = NULL;
         if (minRowCol) {
-            tau = new doublereal[minRowCol];
-            memset(tau, 0, sizeof(doublereal) * minRowCol);
+            tau = new double[minRowCol];
+            memset(tau, 0, sizeof(double) * minRowCol);
         }
         lapack_int *jpvt = NULL;
         if (col) {
             jpvt = new lapack_int[col];
             memset(jpvt, 0, sizeof(lapack_int) * col);
         }
-        doublereal *work = NULL;
+        double *work = NULL;
         if (lwork) {
-            work = new doublereal[lwork];
+            work = new double[lwork];
             memset(work, 0, lwork);
         }
 
@@ -224,7 +224,7 @@ namespace ls {
         //Log(lDebug5) << "before memcpy" << endl;
 
         // set R to A before calling dorgqr
-        memcpy(R, A, sizeof(doublereal) * row * col);
+        memcpy(R, A, sizeof(double) * row * col);
 
         //Log(lDebug5) << "after memcpy" << endl;
 
@@ -320,12 +320,12 @@ namespace ls {
         lapack_int lwork = 16 * col;
         lapack_int minRowCol = min(row, col);
 
-        doublereal *Q = new doublereal[row * row];
-        doublereal *R = new doublereal[row * col];
-        doublereal *tau = new doublereal[minRowCol];
-        doublereal *work = new doublereal[lwork];
+        double *Q = new double[row * row];
+        double *R = new double[row * col];
+        double *tau = new double[minRowCol];
+        double *work = new double[lwork];
 
-        doublereal *A = (doublereal *) oMatrix.getCopy(true);
+        double *A = (double *) oMatrix.getCopy(true);
 
 
         //Log(lDebug5) << "Input:\n"<<ls::print(row, col, A);
@@ -435,15 +435,15 @@ namespace ls {
         lapack_int lwork = 3 * min_MN * min_MN + max(max_MN, 4 * min_MN * min_MN + 4 * min_MN); // 'A'
 
         // allocate arrays for lapack
-        doublereal *A = oTranspose->getCopy(true);
-        doublereal *S = new doublereal[min_MN];
-        memset(S, 0, sizeof(doublereal) * min_MN);
-        doublereal *work = new doublereal[lwork];
-        memset(work, 0, sizeof(doublereal) * lwork);
-        doublereal *U = new doublereal[numRows * numRows];
-        memset(U, 0, sizeof(doublereal) * numRows * numRows);
-        doublereal *VT = new doublereal[numCols * numCols];
-        memset(VT, 0, sizeof(doublereal) * numCols * numCols);
+        double *A = oTranspose->getCopy(true);
+        double *S = new double[min_MN];
+        memset(S, 0, sizeof(double) * min_MN);
+        double *work = new double[lwork];
+        memset(work, 0, sizeof(double) * lwork);
+        double *U = new double[numRows * numRows];
+        memset(U, 0, sizeof(double) * numRows * numRows);
+        double *VT = new double[numCols * numCols];
+        memset(VT, 0, sizeof(double) * numCols * numCols);
         lapack_int *iwork = new lapack_int[8 * min_MN];
 
         lapack_int info;
@@ -517,11 +517,11 @@ namespace ls {
 
         lapack_int lwork = 3 * min_MN + max(max_MN, 7 * min_MN);    // specified in dgesdd description
 
-        doublereal *A = oMatrix.getCopy(true);
-        doublereal *S = new doublereal[min_MN];
-        memset(S, 0, sizeof(doublereal) * min_MN);
-        doublereal *work = new doublereal[lwork];
-        memset(work, 0, sizeof(doublereal) * lwork);
+        double *A = oMatrix.getCopy(true);
+        double *S = new double[min_MN];
+        memset(S, 0, sizeof(double) * min_MN);
+        double *work = new double[lwork];
+        memset(work, 0, sizeof(double) * lwork);
         lapack_int *iwork = new lapack_int[8 * min_MN];
 
         lapack_int info;
@@ -564,8 +564,8 @@ namespace ls {
         memset(vr, 0, sizeof(lapack_complex_double) * numRows * numRows);
         lapack_complex_double *work = new lapack_complex_double[lwork];
         memset(work, 0, sizeof(lapack_complex_double) * lwork);
-        doublereal *rwork = new doublereal[lwork];
-        memset(rwork, 0, sizeof(doublereal) * lwork);
+        double *rwork = new double[lwork];
+        memset(rwork, 0, sizeof(double) * lwork);
 
         int index;
         for (int i = 0; i < numRows; i++) {
@@ -623,8 +623,8 @@ namespace ls {
         memset(vr, 0, sizeof(lapack_complex_double) * numRows * numRows);
         lapack_complex_double *work = new lapack_complex_double[lwork];
         memset(work, 0, sizeof(lapack_complex_double) * lwork);
-        doublereal *rwork = new doublereal[lwork];
-        memset(rwork, 0, sizeof(doublereal) * lwork);
+        double *rwork = new double[lwork];
+        memset(rwork, 0, sizeof(double) * lwork);
 
         int index;
         for (int i = 0; i < numRows; i++) {
@@ -678,15 +678,15 @@ namespace ls {
         lapack_int lwork = 3 * min_MN * min_MN +
                         max(max_MN, 4 * min_MN * min_MN + 4 * min_MN); // specified in dgesdd description for job 'A'
 
-        doublereal *A = inputMatrix.getCopy(true);
-        doublereal *U = new doublereal[numRows * numRows];
-        memset(U, 0, sizeof(doublereal) * numRows * numRows);
-        doublereal *VT = new doublereal[numCols * numCols];
-        memset(VT, 0, sizeof(doublereal) * numCols * numCols);
-        doublereal *S = new doublereal[min_MN];
-        memset(S, 0, sizeof(doublereal) * min_MN);
-        doublereal *work = new doublereal[lwork];
-        memset(work, 0, sizeof(doublereal) * lwork);
+        double *A = inputMatrix.getCopy(true);
+        double *U = new double[numRows * numRows];
+        memset(U, 0, sizeof(double) * numRows * numRows);
+        double *VT = new double[numCols * numCols];
+        memset(VT, 0, sizeof(double) * numCols * numCols);
+        double *S = new double[min_MN];
+        memset(S, 0, sizeof(double) * min_MN);
+        double *work = new double[lwork];
+        memset(work, 0, sizeof(double) * lwork);
         lapack_int *iwork = new lapack_int[8 * min_MN];
 
 
@@ -751,12 +751,12 @@ namespace ls {
         memset(U, 0, sizeof(lapack_complex_double) * numRows * numRows);
         lapack_complex_double *VT = new lapack_complex_double[numCols * numCols];
         memset(VT, 0, sizeof(lapack_complex_double) * numCols * numCols);
-        doublereal *S = new doublereal[min_MN];
-        memset(S, 0, sizeof(doublereal) * min_MN);
+        double *S = new double[min_MN];
+        memset(S, 0, sizeof(double) * min_MN);
         lapack_complex_double *work = new lapack_complex_double[lwork];
         memset(work, 0, sizeof(lapack_complex_double) * lwork);
-        doublereal *rwork = new doublereal[lrwork];
-        memset(rwork, 0, sizeof(doublereal) * lrwork);
+        double *rwork = new double[lrwork];
+        memset(rwork, 0, sizeof(double) * lrwork);
         lapack_int *iwork = new lapack_int[8 * min_MN];
 
         int index;
@@ -817,7 +817,7 @@ namespace ls {
             return 0.0;
         }
 
-        doublereal *A = (doublereal *) oMatrix.getCopy(true);
+        double *A = (double *) oMatrix.getCopy(true);
         lapack_int *vecP = new lapack_int[minRC];
         memset(vecP, 0, (sizeof(lapack_int) * minRC));
 
@@ -826,7 +826,7 @@ namespace ls {
         char norm = '1';
         lapack_int order = numRows * numCols;
 
-        double *work = new doublereal[4 * order];
+        double *work = new double[4 * order];
         memset(work, 0, sizeof(double) * 4 * order);
 
         double dnorm = dlange_(&norm, &numRows, &numCols, A, &numRows, work);
@@ -871,7 +871,7 @@ namespace ls {
             return oResult;
         }
 
-        doublereal *A = (doublereal *) oMatrix.getCopy(true);
+        double *A = (double *) oMatrix.getCopy(true);
         lapack_int *vecP = new lapack_int[minRC];
         memset(vecP, 0, (sizeof(lapack_int) * minRC));
 
@@ -946,7 +946,7 @@ namespace ls {
             throw ApplicationException("Input Matrix must be square", "Expecting a Square Matrix");
 
 
-        doublereal *A = (doublereal *) oMatrix.getCopy(true);
+        double *A = (double *) oMatrix.getCopy(true);
         lapack_int *vecP = new lapack_int[numRows];
         memset(vecP, 0, (sizeof(lapack_int) * numRows));
         lapack_int *vecQ = new lapack_int[numRows];
@@ -1033,11 +1033,11 @@ namespace ls {
             throw ApplicationException("Input Matrix must be square", "Expecting a Square Matrix");
 
 
-        doublereal *A = oMatrix.getCopy(true);
+        double *A = oMatrix.getCopy(true);
         lapack_int *ipvt = new lapack_int[numRows];
         memset(ipvt, 0, sizeof(lapack_int) * numRows);
-        doublereal *work = new doublereal[numRows];
-        memset(work, 0, sizeof(doublereal) * numRows);
+        double *work = new double[numRows];
+        memset(work, 0, sizeof(double) * numRows);
 
         //Log(lDebug5) << "Input Matrix 1D: \n"<<ls::print(numRows, numRows, A);
 


### PR DESCRIPTION
Hi,

Although this pull request is not ready for merge, I am creating it to gather some feedback and start a discussion on modernising `rr-libstruct`. Clapack is now obsolete and has been replaced by Lapacke. As a results many Linux distributions (such as Ubuntu/Debian) ship lapacke rather than clapack.  Since libroadrunner depends on rr-libstruct this prevents roadrunnner and all other applications such as tellurium from being packaged for these distributions, which would otherwise make their installation as easy as `apt install tellurium`. 

The commits in this pull request transitions the rr-libstruct code base *almost* completely to lapacke. Specifically the changes made are

1. `integer` data type has been replaced by `lapack_int`. It could also possible be replaced by `int`.
2. `doublereal` data type has been replaced by `double`
3. All (except one - see below) clapack functions have been repaced by their lapacke equivalents (`LAPACKE_` ...).
4. Lapacke `_work` functions were not used and related work matrices were removed since this made the code a little simpler.
5. It was assumed that all matrices passed to Lapacke was in row major order. This I am unsure about as I am not familiar with this codebase.

The one function that could not be replaced was `dgetc2` (LU factorization with full pivoting). A corresponding function does not seem to be available in lapacke. Again since I am not familiar with this codebase I can not access how important full pivoting is for its use cases. As far as I am aware full pivoting is rarely necessary and usually does not do better than partial pivoting. If this issue can be resolved along with any others you may raise, this pull request can be finalised.

I would be grateful for you comments and insights on this work in progress pull request.